### PR TITLE
Redirect / to /es

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,7 +5,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
   const { url } = context;
   const { pathname } = new URL(url);
   if (pathname === '/') {
-    return context.redirect('/es/');
+    return context.redirect('/es', 307);
   }
   return next();
 };


### PR DESCRIPTION
This pull request updates the redirect behavior for the root path in the middleware. The change ensures that requests to `/` are redirected to `/es` using a temporary redirect (HTTP status 307), which preserves the request method and body.

* Middleware redirect logic: Updated the redirect from `/` to `/es` to use HTTP status code 307 instead of the default, ensuring a temporary redirect and preserving the original request method. (`src/middleware.ts`)