### PR TITLE
Develop

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,4 +6,7 @@ import tailwind from "@astrojs/tailwind";
 export default defineConfig({
   site: "https://astro-nano-demo.vercel.app",
   integrations: [mdx(), sitemap(), tailwind()],
+  redirects: {
+    '/': { destination: '/es', status: 307 },
+  },
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,4 @@ import tailwind from "@astrojs/tailwind";
 export default defineConfig({
   site: "https://astro-nano-demo.vercel.app",
   integrations: [mdx(), sitemap(), tailwind()],
-  redirects: {
-    '/': { destination: '/es', status: 307 },
-  },
 });

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -18,7 +18,7 @@ import { translations } from "@lib/i18n";
           const lang = Astro.url.pathname.startsWith('/en') ? 'en' : 'es';
           const t = translations[lang];
           const year = new Date().getFullYear();
-          return <>&copy; {year} | {SITE.NAME} &mdash; {t.footer.copyright}</>;
+          return <>&copy; {year} | {SITE.NAME}</>;
         })()}
       </div>
       <div class="flex flex-wrap gap-1 items-center">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,5 @@
 import type { MiddlewareHandler } from 'astro';
 
-// Redirect root "/" to "/es/" by default. Adjust as needed.
 export const onRequest: MiddlewareHandler = async (context, next) => {
-  const { url } = context;
-  const { pathname } = new URL(url);
-  if (pathname === '/') {
-    return context.redirect('/es', 307);
-  }
   return next();
 };

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "source": "/",
+      "destination": "/es",
+      "permanent": false
+    }
+  ]
+}


### PR DESCRIPTION
This pull request updates the site's default language redirection logic and simplifies the footer copyright text. The main changes include removing the middleware-based root redirect in favor of a Vercel configuration and streamlining the footer display.

**Language redirection updates:**

* Removed the root path (`"/"`) redirect logic from `src/middleware.ts`, so requests to the root are no longer handled by middleware.
* Added a redirect rule to `vercel.json` to send requests from `"/"` to `"/es"`, centralizing redirection in deployment configuration.

**Footer simplification:**

* Updated the copyright line in `src/components/Footer.astro` to remove the translated copyright text, showing only the year and site name.