### PR TITLE
Update

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,6 @@ import sitemap from "@astrojs/sitemap";
 import tailwind from "@astrojs/tailwind";
 
 export default defineConfig({
-  site: "https://astro-nano-demo.vercel.app",
+  site: "https://sailingnotes.com",
   integrations: [mdx(), sitemap(), tailwind()],
 });


### PR DESCRIPTION
This pull request updates the site URL in the Astro configuration to reflect the new production domain. This ensures that generated metadata and integrations, such as the sitemap, reference the correct site address. 

* Changed the `site` property in `astro.config.mjs` from `"https://astro-nano-demo.vercel.app"` to `"https://sailingnotes.com"` to update the production URL.